### PR TITLE
Fix CPU hogging because of continuous etcd fetch

### DIFF
--- a/tendrl/commons/jobs/__init__.py
+++ b/tendrl/commons/jobs/__init__.py
@@ -51,6 +51,8 @@ class JobConsumer(object):
 
     def _acceptor(self):
         while not self.job_consumer_thread._complete.is_set():
+            gevent.sleep(2)
+
             # TODO(team) replace below raw write with a "EtcdJobQueue" class
             try:
                 jobs = tendrl_ns.etcd_orm.client.read("/queue")
@@ -83,7 +85,6 @@ class JobConsumer(object):
                     tendrl_ns.etcd_orm.client.write(job.key, json.dumps(
                         raw_job))
                     break
-            gevent.sleep(2)
 
     def run(self):
         self._acceptor()


### PR DESCRIPTION
This patch fixes CPU hogging because of continuous
fetching of etcd "/queue" by job accptor.

tendrl-bug-id: Tendrl/node-agent#198
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>