### PR TITLE
Removed logging of KeyNotFound error

### DIFF
--- a/tendrl/commons/objects/__init__.py
+++ b/tendrl/commons/objects/__init__.py
@@ -53,7 +53,11 @@ class BaseObject(object):
 
             cls_etcd = cs_utils.to_etcdobj(self._etcd_cls, current_obj)
         except etcd.EtcdKeyNotFound as ex:
-            LOG.error(ex)
+            # No need to log the error. This would keep happening
+            # till first cluster is imported/created or some data
+            # synchronized in central store.
+            # This un-necessarily hog the log as every few seconds
+            # these errors would be logged.
             cls_etcd = cs_utils.to_etcdobj(self._etcd_cls, self)
 
         getattr(NS.central_store_thread, "save_%s" %


### PR DESCRIPTION
This is not required as initially when there is no cluster
synced/created, these errors would keep logging every few
seconds and this would hog the log.

Signed-off-by: Shubhendu <shtripat@redhat.com>