### PR TITLE
Definitions test

### DIFF
--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -7,22 +7,26 @@ import re
 def definitions_node_agent_path_yaml():
     """Get absolute path to definitions file."""
 
-    return os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","..","..","etc/tendrl_definitions_node_agent.yaml"))
+    return os.path.abspath(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "..","..","..","etc/tendrl_definitions_node_agent.yaml"))
 
 def get_run_attributes_from_yaml(file_path):
     """Get list of runable functions from definitions."""
 
     functions = set()
     list_search = False
+    pattern_run = re.compile("run:\s*(?P<run>[a-zA-Z0-9\._]+)")
+    pattern_prun = re.compile("- (?P<_run>[a-zA-Z0-9\._]+)")
     with open(file_path, 'r') as f:
         for line in f:
             if not list_search:
-                match = re.search("run:\s*(?P<run>[a-zA-Z0-9\._]+)", line)
+                match = pattern_run.search(line)
                 if match is not None:
                     functions.add(match.group("run"))
                     list_search = False
             else:
-                match = re.search("- (?P<_run>[a-zA-Z0-9\._]+)", line)
+                match = pattern_prun.search(line)
                 if match is not None:
                     functions.add(match.group("_run"))
                 else:
@@ -33,7 +37,8 @@ def get_run_attributes_from_yaml(file_path):
     return list(functions)
 
 
-@pytest.fixture(params=get_run_attributes_from_yaml(definitions_node_agent_path_yaml()))
+@pytest.fixture(
+    params=get_run_attributes_from_yaml(definitions_node_agent_path_yaml()))
 def definitions_run_attribute(request):
     """Generate function names for import."""
 

--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -3,6 +3,14 @@ import pytest
 import re
 
 
+@pytest.fixture
+def definitions_path():
+    """Get absolute path to definitions file."""
+
+    return os.path.abspath(os.path.dirname(os.path.realpath(__file__)) +
+                           "/../../../etc/tendrl_definitions_node_agent.yaml")
+
+
 def get_defined_functions(file_path):
     """Get list of runable functions from definitions."""
 
@@ -15,9 +23,7 @@ def get_defined_functions(file_path):
     return functions
 
 
-@pytest.fixture(params=get_defined_functions(
-    os.path.dirname(os.path.realpath(__file__)) +
-    "/../../../etc/tendrl_definitions_node_agent.yaml"))
+@pytest.fixture(params=get_defined_functions(definitions_path()))
 def defined_function(request):
     """Generate function names for import."""
 

--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import pytest
+import re
+
+
+def get_defined_functions(file_path):
+    """Get list of runable functions from definitions."""
+
+    functions = []
+    with open(file_path, 'r') as f:
+        for line in f:
+            match = re.search("run:\s*(?P<run>[a-zA-Z0-9-._])*", line)
+            if match is not None:
+                functions.append(match.group())
+    return functions
+
+
+@pytest.fixture(params=get_defined_functions(
+    os.path.dirname(os.path.realpath(__file__)) +
+    "/../../../etc/tendrl_definitions_node_agent.yaml"))
+def defined_function(request):
+    """Generate function names for import."""
+
+return request.param

--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -15,12 +15,24 @@ def get_defined_functions(file_path):
     """Get list of runable functions from definitions."""
 
     functions = []
+    list_search = False
     with open(file_path, 'r') as f:
         for line in f:
-            match = re.search("run:\s*(?P<run>[a-zA-Z0-9-._])*", line)
-            if match is not None:
-                functions.append(match.group())
-    return functions
+            if not list_search:
+                match = re.search("run:\s*(?P<run>[a-zA-Z0-9\._]+)", line)
+                if match is not None:
+                    functions.append(match.group("run"))
+                    list_search = False
+            else:
+                match = re.search("- (?P<_run>[a-zA-Z0-9\._]+)", line)
+                if match is not None:
+                    functions.append(match.group("_run"))
+                else:
+                    list_search = False
+            match2 = re.search("run:$", line)
+            if match2 is not None:
+                list_search = True
+    return list(set(functions))
 
 
 @pytest.fixture(params=get_defined_functions(definitions_path()))

--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -9,7 +9,12 @@ def definitions_node_agent_path_yaml():
 
     return os.path.abspath(
         os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..","..","..","etc/tendrl_definitions_node_agent.yaml"))
+            os.path.dirname(os.path.realpath(__file__)),
+            "..",
+            "..",
+            "..",
+            "etc/tendrl_definitions_node_agent.yaml"))
+
 
 def get_run_attributes_from_yaml(file_path):
     """Get list of runable functions from definitions."""
@@ -42,4 +47,4 @@ def get_run_attributes_from_yaml(file_path):
 def definitions_run_attribute(request):
     """Generate function names for import."""
 
-return request.param
+    return request.param

--- a/tendrl/commons/tests/conftest.py
+++ b/tendrl/commons/tests/conftest.py
@@ -4,39 +4,37 @@ import re
 
 
 @pytest.fixture
-def definitions_path():
+def definitions_node_agent_path_yaml():
     """Get absolute path to definitions file."""
 
-    return os.path.abspath(os.path.dirname(os.path.realpath(__file__)) +
-                           "/../../../etc/tendrl_definitions_node_agent.yaml")
+    return os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","..","..","etc/tendrl_definitions_node_agent.yaml"))
 
-
-def get_defined_functions(file_path):
+def get_run_attributes_from_yaml(file_path):
     """Get list of runable functions from definitions."""
 
-    functions = []
+    functions = set()
     list_search = False
     with open(file_path, 'r') as f:
         for line in f:
             if not list_search:
                 match = re.search("run:\s*(?P<run>[a-zA-Z0-9\._]+)", line)
                 if match is not None:
-                    functions.append(match.group("run"))
+                    functions.add(match.group("run"))
                     list_search = False
             else:
                 match = re.search("- (?P<_run>[a-zA-Z0-9\._]+)", line)
                 if match is not None:
-                    functions.append(match.group("_run"))
+                    functions.add(match.group("_run"))
                 else:
                     list_search = False
             match2 = re.search("run:$", line)
             if match2 is not None:
                 list_search = True
-    return list(set(functions))
+    return list(functions)
 
 
-@pytest.fixture(params=get_defined_functions(definitions_path()))
-def defined_function(request):
+@pytest.fixture(params=get_run_attributes_from_yaml(definitions_node_agent_path_yaml()))
+def definitions_run_attribute(request):
     """Generate function names for import."""
 
 return request.param

--- a/tendrl/commons/tests/test_definitions.py
+++ b/tendrl/commons/tests/test_definitions.py
@@ -2,16 +2,16 @@ import pkgutil
 import yaml
 
 
-def test_valid_definitions(definitions_path):
+def test_valid_definitions(definitions_node_agent_path_yaml):
     """Check if `definitions` file is in a valid YAML format."""
 
     # TODO(fbalak) validate against some schema
     # http://stackoverflow.com/questions/3262569/validating-a-yaml-document-in-python
-    definitions = yaml.safe_load(definitions_path)
+    definitions = yaml.safe_load(definitions_node_agent_path_yaml)
     assert definitions is not None
 
 
-def test_defined_functions(defined_function):
+def test_defined_functions(definitions_run_attribute):
     """Check if `defined_function` can be imported."""
 
-assert pkgutil.find_loader(defined_function)
+assert pkgutil.find_loader(definitions_run_attribute)

--- a/tendrl/commons/tests/test_definitions.py
+++ b/tendrl/commons/tests/test_definitions.py
@@ -2,7 +2,7 @@ import pkgutil
 import yaml
 
 
-def test_valid_definitions(definitions_node_agent_path_yaml):
+def test_yaml_file_validity(definitions_node_agent_path_yaml):
     """Check if `definitions` file is in a valid YAML format."""
 
     # TODO(fbalak) validate against some schema
@@ -11,7 +11,7 @@ def test_valid_definitions(definitions_node_agent_path_yaml):
     assert definitions is not None
 
 
-def test_defined_functions(definitions_run_attribute):
+def test_definitions_node_agent_run_attributes(definitions_run_attribute):
     """Check if `defined_function` can be imported."""
 
 assert pkgutil.find_loader(definitions_run_attribute)

--- a/tendrl/commons/tests/test_definitions.py
+++ b/tendrl/commons/tests/test_definitions.py
@@ -1,4 +1,17 @@
 import pkgutil
+import yaml
+
+
+def test_valid_definitions(definitions_path):
+    """Check if `definitions` file is in a valid YAML format."""
+
+    try:
+        # TODO(fbalak) validate against some schema
+        # http://stackoverflow.com/questions/3262569/validating-a-yaml-document-in-python
+        definitions = yaml.safe_load(definitions_path)
+    except Exception:
+        definitions = None
+    assert definitions is not None
 
 
 def test_defined_functions(defined_function):

--- a/tendrl/commons/tests/test_definitions.py
+++ b/tendrl/commons/tests/test_definitions.py
@@ -5,12 +5,9 @@ import yaml
 def test_valid_definitions(definitions_path):
     """Check if `definitions` file is in a valid YAML format."""
 
-    try:
-        # TODO(fbalak) validate against some schema
-        # http://stackoverflow.com/questions/3262569/validating-a-yaml-document-in-python
-        definitions = yaml.safe_load(definitions_path)
-    except Exception:
-        definitions = None
+    # TODO(fbalak) validate against some schema
+    # http://stackoverflow.com/questions/3262569/validating-a-yaml-document-in-python
+    definitions = yaml.safe_load(definitions_path)
     assert definitions is not None
 
 

--- a/tendrl/commons/tests/test_definitions.py
+++ b/tendrl/commons/tests/test_definitions.py
@@ -1,0 +1,7 @@
+import pkgutil
+
+
+def test_defined_functions(defined_function):
+    """Check if `defined_function` can be imported."""
+
+assert pkgutil.find_loader(defined_function)


### PR DESCRIPTION
This is a work in progress. Do NOT merge.

Add test cases:
test_yaml_file_validity
test_definitions_node_agent_run_attributes

Results of test cases:
```
tendrl/node_agent/tests/test_definitions.py::test_yaml_file_validity PASSED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.objects.Node.atoms.check_node_up] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.atoms.service.validations.check_service_running] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.atoms.node.cmd.Cmd] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.atoms.package.validations.check_package_installed] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.gluster_integration.objects.TendrlContext.atoms.check_cluster_id_exists] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.gluster_integration.objects.Config.atoms.generate.Generate] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.atoms.node.check_node_up] FAILED
tendrl/node_agent/tests/test_definitions.py::test_definitions_node_agent_run_attributes[tendrl.node_agent.objects.TendrlContext.atoms.compare] FAILED
```

Moved from https://github.com/Tendrl/node-agent/pull/283.