### PR TITLE
Write cluster_tendrl_context to proper location

### DIFF
--- a/tendrl/commons/objects/cluster_tendrl_context/__init__.py
+++ b/tendrl/commons/objects/cluster_tendrl_context/__init__.py
@@ -45,5 +45,5 @@ class _ClusterTendrlContextEtcd(EtcdObj):
     _tendrl_cls = ClusterTendrlContext
 
     def render(self):
-        self.__name__ = self.__name__ % NS.node_context.node_id
+        self.__name__ = self.__name__ % NS.tendrl_context.integration_id
         return super(_ClusterTendrlContextEtcd, self).render()


### PR DESCRIPTION
Currently it is written to clusters/<node-id>/TendrlContext
This is fixed in this PR

tendrl-bug-id: Tendrl/commons#302
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>