### PR TITLE
Adds internal flows

### DIFF
--- a/tendrl/commons/flows/__init__.py
+++ b/tendrl/commons/flows/__init__.py
@@ -11,6 +11,12 @@ LOG = logging.getLogger(__name__)
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseFlow(object):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "internal"):
+            if hasattr(cls, "load_definition"):
+                raise Exception("Non internal Flow cannot use load_definition, must have definition in (.yml)")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, parameters=None, job_id=None):
         # Tendrl internal flows should populate their own self._defs
         if not hasattr(self, "internal"):
@@ -20,6 +26,9 @@ class BaseFlow(object):
         self.job_id = job_id
         self.parameters.update({'job_id': self.job_id})
         self.parameters.update({'flow_id': self._defs['uuid']})
+        if hasattr(self, "internal"):
+            if not hasattr(self, "_defs"):
+                raise Exception("Internal Flow must provide its own definition via '_defs' attr")
 
     def load_definition(self):
         cls_name = self.__class__.__name__


### PR DESCRIPTION
Adds "internal" class variable to all flows
Use "internal=True" for flows which are internal and not in definitions (.yml)
Internal flows have to provide their own definition via "_defs" attribute