### PR TITLE
Adds internal objects, atoms

### DIFF
--- a/tendrl/commons/objects/__init__.py
+++ b/tendrl/commons/objects/__init__.py
@@ -11,10 +11,19 @@ LOG = logging.getLogger(__name__)
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseObject(object):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "internal"):
+            if hasattr(cls, "load_definition"):
+                raise Exception("Non internal Object cannot use load_definition, must have definition in (.yml)")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self):
         # Tendrl internal objects should populate their own self._defs
         if not hasattr(self, "internal"):
             self._defs = self.load_definition()
+        if hasattr(self, "internal"):
+            if not hasattr(self, "_defs"):
+                raise Exception("Internal Object must provide its own definition via '_defs' attr")
 
     def __new__(cls, *args, **kwargs):
 
@@ -71,12 +80,21 @@ class BaseObject(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseAtom(object):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "internal"):
+            if hasattr(cls, "load_definition"):
+                raise Exception("Non internal Atom cannot use load_definition, must have definition in (.yml)")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, parameters=None):
         self.parameters = parameters
 
         # Tendrl internal atoms should populate their own self._defs
         if not hasattr(self, "internal"):
             self._defs = self.load_definition()
+        if hasattr(self, "internal"):
+            if not hasattr(self, "_defs"):
+                raise Exception("Internal Atom must provide its own definition via '_defs' attr")
 
     def load_definition(self):
         LOG.debug("Load definitions for namespace.%s.objects.%s.atoms.%s",


### PR DESCRIPTION
Adds "internal" class variable to objects, atoms
Use "internal=True" for objects, atoms which are internal and not in definitions (.yml)
Internal objects, atoms have to provide their own definition via "_defs" attribute