### PR TITLE
Cleanup cat command from code

### DIFF
--- a/tendrl/commons/utils/cmd_utils.py
+++ b/tendrl/commons/utils/cmd_utils.py
@@ -18,7 +18,6 @@ SAFE_COMMAND_LIST = [
     "config_manager",
     "systemctl",
     "hwinfo",
-    "cat",
     "ping"
 ]
 


### PR DESCRIPTION
I have already removed cat command from cmd_utils (https://github.com/Tendrl/commons/pull/297/files#diff-216815e55af1fc237caa680457e88c81L12) but again i see cat command in same file so i am removing this, 

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>