### PR TITLE
Provision gluster provisioner after import

### DIFF
--- a/tendrl/commons/flows/import_cluster/__init__.py
+++ b/tendrl/commons/flows/import_cluster/__init__.py
@@ -74,8 +74,9 @@ class ImportCluster(flows.BaseFlow):
                             flow_id = self.parameters['flow_id'],
                             priority="info",
                             publisher=NS.publisher_id,
-                            payload={"message": "Check: Node %s not part of any other cluster" % entry
-                                 }
+                            payload={
+                                "message": "Check: Node %s not part of any other cluster" % entry
+                            }
                         )
                     )
 
@@ -145,7 +146,10 @@ class ImportCluster(flows.BaseFlow):
             node_context = NS.node_context.load()
             is_mon = False
             for tag in json.loads(node_context.tags):
-                if "ceph/mon" in tag:
+                mon_tag = NS.compiled_definitions.get_parsed_defs()[
+                    'namespace.tendrl'
+                ]['tags']['ceph-mon']
+                if mon_tag in tag:
                     is_mon = True
             if is_mon:
                 # Check if minimum required version of underlying ceph

--- a/tendrl/commons/flows/import_cluster/ceph_help.py
+++ b/tendrl/commons/flows/import_cluster/ceph_help.py
@@ -73,12 +73,16 @@ def import_ceph(parameters):
               'w+') as f:
         f.write(pkg_resources.resource_string(__name__, logging_file_name))
 
+    ceph_integration_tag = NS.compiled_definitions.get_parsed_defs()[
+        'namespace.tendrl'
+    ]['tags']['tendrl-ceph-integration']
+
     config_data = {"etcd_port": int(NS.config.data['etcd_port']),
                    "etcd_connection": str(NS.config.data['etcd_connection']),
                    "log_cfg_path": logging_config_file_path + logging_file_name,
                    "log_level": "DEBUG",
                     "logging_socket_path": "/var/run/tendrl/message.sock",
-                    "tags": json.dumps(["tendrl/integration/ceph"])}
+                    "tags": json.dumps([ceph_integration_tag])}
     with open("/etc/tendrl/ceph-integration/ceph-integration.conf.yaml",
               'w') as outfile:
         yaml.dump(config_data, outfile, default_flow_style=False)

--- a/tendrl/commons/flows/import_cluster/gluster_help.py
+++ b/tendrl/commons/flows/import_cluster/gluster_help.py
@@ -73,14 +73,16 @@ def import_gluster(parameters):
     with open(logging_config_file_path + logging_file_name,
               'w+') as f:
         f.write(pkg_resources.resource_string(__name__, logging_file_name))
-
+    gluster_integration_tag = NS.compiled_definitions.get_parsed_defs()[
+        'namespace.tendrl'
+    ]['tags']['tendrl-gluster-integration']
     config_data = {"etcd_port": int(NS.config.data['etcd_port']),
                    "etcd_connection": str(NS.config.data['etcd_connection']),
                    "log_cfg_path": logging_config_file_path +
                                    logging_file_name,
                    "log_level": "DEBUG",
                     "logging_socket_path": "/var/run/tendrl/message.sock",
-                    "tags": json.dumps(["tendrl/integration/gluster"])}
+                    "tags": json.dumps([gluster_integration_tag])}
     with open("/etc/tendrl/gluster-integration/gluster-integration.conf.yaml",
               'w') as outfile:
         yaml.dump(config_data, outfile, default_flow_style=False)

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -4,6 +4,17 @@ namespace.tendrl:
   min_reqd_ceph_ver: 10.2.5
   ceph_provisioner: CephInstallerPlugin
   gluster_provisioner: GdeployPlugin
+  tags:
+    tendrl-node-agent: "tendrl/node"
+    etcd: "tendrl/central-store"
+    tendrl-apid: "tendrl/server"
+    tendrl-gluster-integration: "tendrl/integration/gluster"
+    tendrl-ceph-integration: "tendrl/integration/ceph"
+    glusterd: "gluster/server"
+    ceph-mon: "ceph/mon"
+    ceph-osd: "ceph/osd"
+    gluster-provisioner: "provisioner/gluster"
+    ceph-provisioner: "provisioner/ceph"
   flows:
     CreateCluster:
       help: "Create a cluster from scratch"


### PR DESCRIPTION
This patch aims at provisioning the gluster
prvisioner (gdeploy and python-gdeploy) after
the gluster cluster import has happened. This
sets the tag of that node as "gluster/provisioner"
and all the gluster management calls must be
targeted at this node.

tendrl-bug-id: Tendrl/commons#264
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>