### PR TITLE
Provision gluster provisioner

### DIFF
--- a/tendrl/commons/flows/create_cluster/__init__.py
+++ b/tendrl/commons/flows/create_cluster/__init__.py
@@ -45,6 +45,15 @@ class CreateCluster(flows.BaseFlow):
                 )
 
                 all_ssh_jobs_done = True
+                # set this node as gluster provisioner
+                if "gluster" in self.parameters["TendrlContext.sds_name"]:
+                    tags = ["provisioner/%s" % integration_id]
+                    NS.node_context = NS.node_context.load()
+                    current_tags = json.loads(NS.node_context.tags)
+                    tags += current_tags
+                    NS.node_context.tags = list(set(tags))
+                    NS.node_context.save()
+
 
         # SSH setup jobs finished above, now install sds bits and create cluster
         if "ceph" in self.parameters["TendrlContext.sds_name"]:
@@ -97,6 +106,8 @@ class CreateCluster(flows.BaseFlow):
         sds_pkg_name = NS.etcd_orm.client.read(
             "nodes/%s/DetectedCluster/sds_pkg_name" % self.parameters['Node[]'][0]
         ).value
+        if "gluster" in sds_pkg_name:
+            new_params['gdeploy_provisioned'] = True
         sds_pkg_version = NS.etcd_orm.client.read(
             "nodes/%s/DetectedCluster/sds_pkg_version" % self.parameters['Node[]'][0]
         ).value

--- a/tendrl/commons/flows/import_cluster/__init__.py
+++ b/tendrl/commons/flows/import_cluster/__init__.py
@@ -10,6 +10,7 @@ from tendrl.commons.objects.job import Job
 
 from tendrl.commons import flows
 from tendrl.commons.event import Event
+from tendrl.commons.flows import utils
 from tendrl.commons.message import Message
 from tendrl.commons.flows.exceptions import FlowExecutionFailedError
 from tendrl.commons.flows.import_cluster.ceph_help import import_ceph
@@ -86,6 +87,42 @@ class ImportCluster(flows.BaseFlow):
                      }
             )
         )
+
+        # check if gdeploy in already provisioned in this cluster
+        # if no it has to be provisioned here
+        if not self.parameters.get('gdeploy_provisioned', False):
+            ssh_job_ids = utils.gluster_create_ssh_setup_jobs(self.parameters)
+
+            all_ssh_jobs_done = False
+            while not all_ssh_jobs_done:
+                all_status = []
+                for job_id in ssh_job_ids:
+                    all_status.append(NS.etcd_orm.client.read("/queue/%s/status" %
+                                                              job_id).value)
+                if all([status for status in all_status if status == "finished"]):
+                    Event(
+                        Message(
+                            job_id=self.parameters['job_id'],
+                            flow_id = self.parameters['flow_id'],
+                            priority="info",
+                            publisher=NS.publisher_id,
+                            payload={"message": "SSH setup completed for all nodes in cluster %s" % integration_id
+                                 }
+                        )
+                    )
+                    all_ssh_jobs_done = True
+
+                    # set this node as gluster provisioner
+                    tags = ["provisioner/%s" % integration_id]
+                    NS.node_context = NS.node_context.load()
+                    current_tags = json.loads(NS.node_context.tags)
+                    tags += current_tags
+                    NS.node_context.tags = list(set(tags))
+                    NS.node_context.save()
+
+                    # set gdeploy_provisioned to true so that no other nodes
+                    # tries to configure gdeploy
+                    self.parameters['gdeploy_provisioned'] = True
 
         node_list = self.parameters['Node[]']
         cluster_nodes = []


### PR DESCRIPTION
This patch aims at provisioning the gluster
prvisioner (gdeploy and python-gdeploy) before
the gluster cluster import and create flow. This
sets the tag of that node as "gluster/provisioner"
and all the gluster management calls must be
targeted at this node.

tendrl-bug-id: Tendrl/commons#264
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>