### PR TITLE
Correcting exception message in job

### DIFF
--- a/tendrl/commons/jobs/__init__.py
+++ b/tendrl/commons/jobs/__init__.py
@@ -126,14 +126,21 @@ class JobConsumerThread(gevent.greenlet.Greenlet):
                             Event(
                                 ExceptionMessage(
                                     priority="error",
-                                    job_id=job.job_id,
-                                    flow_id = the_flow.parameters['flow_id'],
                                     publisher=NS.publisher_id,
                                     payload={"message": "error",
                                              "exception": e
                                              }
                                 )
                             )
+                            Event(
+                                Message(
+                                    job_id=job.job_id,
+                                    flow_id = the_flow.parameters['flow_id'],
+                                    priority="error",
+                                    publisher=NS.publisher_id,
+                                    payload={"message": "Job failed"}
+                                )
+                            ) 
                             try:
                                 NS.etcd_orm.client.write(job_status_key, "failed", prevValue="processing")
                             except etcd.EtcdCompareFailed:


### PR DESCRIPTION
ExceptionMessage and job updates are different, because exception message have traceback, traceback should not shown to user. Exception message class only tack payload, priority and publisher, otherwise it give keyerror.

Signed-off-by: root <root@dhcp43-207.lab.eng.blr.redhat.com>