### PR TITLE
Flag to convert ansible command module to shell module

### DIFF
--- a/tendrl/commons/utils/cmd_utils.py
+++ b/tendrl/commons/utils/cmd_utils.py
@@ -29,10 +29,10 @@ class UnsupportedCommandException(Exception):
 
 
 class Command(object):
-    def __init__(self, command):
+    def __init__(self, command, shell=False):
         if shlex.split(command)[0] not in SAFE_COMMAND_LIST:
             raise UnsupportedCommandException(command.split()[0])
-        self.attributes = {"_raw_params": command}
+        self.attributes = {"_raw_params": command, '_uses_shell': shell}
 
     def run(self):
         try:


### PR DESCRIPTION
Using  _uses_shell flag command module can support the shell commands also

Signed-off-by: root <root@dhcp43-149.lab.eng.blr.redhat.com>