### PR TITLE
Added condition to check messages comes with empty cluster_id

### DIFF
--- a/tendrl/commons/logger.py
+++ b/tendrl/commons/logger.py
@@ -48,7 +48,8 @@ class Logger(object):
     def push_message(self):
         if self.message.priority not in ["info", "debug"]:
             # Storing messages cluster wise
-            if self.message.cluster_id is not None:
+            if (self.message.cluster_id is not None) and (
+                self.message.cluster_id != ""):
                 NS.node_agent.objects.ClusterMessage(
                     message_id=self.message.message_id,
                     timestamp=self.message.timestamp,


### PR DESCRIPTION
some places empty cluster id is used before it assign for example : https://github.com/Tendrl/node-agent/blob/develop/tendrl/node_agent/provisioner/gluster/plugins/gdeploy.py, This time cluster_id is not available. So it store messages like /clusters/messages/.

Signed-off-by: root <root@dhcp43-207.lab.eng.blr.redhat.com>