### PR TITLE
Resolving name conflicts

### DIFF
--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -247,7 +247,7 @@ namespace.tendrl:
           help: "sysfs bus id"
           type: String
         alignment:
-          help: "alignement"
+          help: "alignment"
           type: String
         read_only:
           help: "disk is read only or not"
@@ -289,7 +289,7 @@ namespace.tendrl:
           help: "discard max bytes"
           type: String
         discard_zeros_data:
-          help: "discard zeroes data"
+          help: "discard zeros data"
           type: String
         optimal_io_size:
           help: "optimal I/O size"

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -174,7 +174,7 @@ namespace.tendrl:
         mount_point:
           help: "disk mount point"
           type: String
-        Model:
+        model:
           help: "disk model name"
           type: String
         vendor:
@@ -246,7 +246,7 @@ namespace.tendrl:
         sysfs_busid:
           help: "sysfs bus id"
           type: String
-        alignement:
+        alignment:
           help: "alignement"
           type: String
         read_only:
@@ -288,7 +288,7 @@ namespace.tendrl:
         discard_max_bytes:
           help: "discard max bytes"
           type: String
-        discard_zeroes_data:
+        discard_zeros_data:
           help: "discard zeroes data"
           type: String
         optimal_io_size:


### PR DESCRIPTION
There are name conflicts between attributes derived from master.yaml file and attributes of object derived from _get_object() in tendrl/commons__init__.py