### PR TITLE
Added a pre run atom for checking validity of node

### DIFF
--- a/tendrl/commons/flows/__init__.py
+++ b/tendrl/commons/flows/__init__.py
@@ -167,35 +167,9 @@ class BaseFlow(object):
             )
         )
 
-        for atom_fqn in self._defs.get("atoms"):
-            msg = "Start atom : %s" % atom_fqn
-            Event(
-                Message(
-                    priority="info",
-                    publisher=NS.publisher_id,
-                    payload={"message": msg}
-                )
-            )
-
-            ret_val = self._execute_atom(atom_fqn)
-
-            if not ret_val:
-                msg = "Failed atom: %s on flow: %s" % \
-                      (atom_fqn, self._defs['help'])
-                Event(
-                    Message(
-                        priority="error",
-                        publisher=NS.publisher_id,
-                        payload={"message": msg}
-                    )
-                )
-                raise AtomExecutionFailedError(
-                    "Error executing atom: %s on flow: %s" %
-                    (atom_fqn, self._defs['help'])
-                )
-            else:
-                msg = 'Finished atom %s for flow: %s' %\
-                      (atom_fqn, self._defs['help'])
+        if self._defs.get("atoms") is not None:
+            for atom_fqn in self._defs.get("atoms"):
+                msg = "Start atom : %s" % atom_fqn
                 Event(
                     Message(
                         priority="info",
@@ -203,6 +177,33 @@ class BaseFlow(object):
                         payload={"message": msg}
                     )
                 )
+
+                ret_val = self._execute_atom(atom_fqn)
+
+                if not ret_val:
+                    msg = "Failed atom: %s on flow: %s" % \
+                          (atom_fqn, self._defs['help'])
+                    Event(
+                        Message(
+                            priority="error",
+                            publisher=NS.publisher_id,
+                            payload={"message": msg}
+                        )
+                    )
+                    raise AtomExecutionFailedError(
+                        "Error executing atom: %s on flow: %s" %
+                        (atom_fqn, self._defs['help'])
+                    )
+                else:
+                    msg = 'Finished atom %s for flow: %s' %\
+                          (atom_fqn, self._defs['help'])
+                    Event(
+                        Message(
+                            priority="info",
+                            publisher=NS.publisher_id,
+                            payload={"message": msg}
+                        )
+                    )
 
         # Execute the post runs for the flow
         msg = "Processing post-runs for flow: %s" % self._defs['help']

--- a/tendrl/commons/flows/create_cluster/__init__.py
+++ b/tendrl/commons/flows/create_cluster/__init__.py
@@ -24,7 +24,7 @@ class CreateCluster(flows.BaseFlow):
         if sds_name not in supported_sds:
             raise FlowExecutionFailedError("SDS (%s) not supported" % sds_name)
         
-        # Check if clusre name contains space char and fail if so
+        # Check if cluster name contains space char and fail if so
         if ' ' in self.parameters['TendrlContext.cluster_name']:
             Event(
                 Message(
@@ -41,6 +41,14 @@ class CreateCluster(flows.BaseFlow):
             raise FlowExecutionFailedError(
                 "Space char not allowed in cluster name"
             )
+
+        # Execute super run() to execute pre-runs
+        # Note: this super call would make execution of atom's pre_run, run and post_run
+        # Currently there is no atoms defined for create cluster flow.
+        # TODO (team): break down run() into run_pre(), run_atom(), run_post() where we
+        # run the pre_runs, atoms, post_runs respectively so run() simply calls
+        # run_pre(), run_atom(), run_post()
+        super(CreateCluster, self).run()
 
         ssh_job_ids = []
         if "ceph" in sds_name:
@@ -85,7 +93,6 @@ class CreateCluster(flows.BaseFlow):
                     NS.node_context.save()
                 break
 
-                                               
         Event(
             Message(
                 job_id=self.parameters['job_id'],

--- a/tendrl/commons/flows/import_cluster/__init__.py
+++ b/tendrl/commons/flows/import_cluster/__init__.py
@@ -15,11 +15,18 @@ from tendrl.commons.message import Message
 
 class ImportCluster(flows.BaseFlow):
     def run(self):
-
         integration_id = self.parameters['TendrlContext.integration_id']
         if integration_id is None:
             raise FlowExecutionFailedError("TendrlContext.integration_id cannot be empty")
         sds_name = self.parameters['DetectedCluster.sds_pkg_name']
+
+        # Invoke the super run() for pre-runs execution
+        # Note: this super call would make execution of atom's pre_run, run and post_run
+        # Currently there is no atoms defined for import cluster flow.
+        # TODO (team): break down run() into run_pre(), run_atom(), run_post() where we
+        # run the pre_runs, atoms, post_runs respectively so run() simply calls
+        # run_pre(), run_atom(), run_post()
+        super(ImportCluster, self).run()
 
         if not self.parameters.get('import_after_expand', False) and \
             not self.parameters.get('import_after_create', False):

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -37,6 +37,8 @@ namespace.tendrl:
           - TendrlContext.integration_id
           - Cluster.node_configuration
           - Cluster.conf_overrides
+      pre_run:
+        - tendrl.objects.Node.atoms.IsNodeTendrlManaged
       run: tendrl.flows.CreateCluster
       type: Create
       uuid: 2f94a48a-05d7-408c-b400-e27827f4eacd
@@ -68,10 +70,10 @@ namespace.tendrl:
       inputs:
         mandatory:
           - "Node[]"
-          - DetectedCluster.detected_cluster_id
           - DetectedCluster.sds_pkg_name
-          - DetectedCluster.sds_pkg_version
           - TendrlContext.integration_id
+      pre_run:
+        - tendrl.objects.Node.atoms.IsNodeTendrlManaged
       run: tendrl.flows.ImportCluster
       type: Create
       uuid: 2f94a48a-05d7-408c-b400-e27827f4edef
@@ -352,6 +354,16 @@ namespace.tendrl:
       help: "BlockDevice"
     Node:
       atoms:
+        IsNodeTendrlManaged:
+          help: Check if a node is being managed by tendrl
+          enabled: true
+          inputs:
+            mandatory:
+              - "Node[]"
+          run: tendrl.objects.Node.atoms.IsNodeTendrlManaged
+          type: check
+          uuid: 2f94a48a-05d7-408c-b400-e27827f4edca
+          version: 1
         Cmd:
           enabled: true
           inputs:

--- a/tendrl/commons/objects/node/atoms/is_node_tendrl_managed/__init__.py
+++ b/tendrl/commons/objects/node/atoms/is_node_tendrl_managed/__init__.py
@@ -1,0 +1,90 @@
+import etcd
+
+from tendrl.commons import objects
+from tendrl.commons.objects import AtomExecutionFailedError
+
+
+class IsNodeTendrlManaged(objects.BaseAtom):
+    def __init__(self, *args, **kwargs):
+        super(IsNodeTendrlManaged, self).__init__(*args, **kwargs)
+
+    def run(self):
+        node_ids = self.parameters.get('Node[]')
+        if not node_ids or len(node_ids) == 0:
+            raise AtomExecutionFailedError("Node[] cannot be empty")
+
+        for node_id in node_ids:
+            # Check if node has the OS details populated
+            try:
+                os_details = NS._int.client.read("nodes/%s/Os" % node_id)
+                if os_details.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have OS details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have OS details populated"
+                )
+
+            # Check if node has the CPU details populated
+            try:
+                cpu_details = NS._int.client.read("nodes/%s/Cpu" % node_id)
+                if cpu_details.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have CPU details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have CPU details populated"
+                )
+
+            # Check if node has the Memory populated
+            try:
+                memory_details = NS._int.client.read("nodes/%s/Memory" % node_id)
+                if memory_details.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have Memory details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have Memory details populated"
+                )
+
+            # Check if node has the block devices populated
+            try:
+                block_devices = NS._int.client.read("nodes/%s/BlockDevices" % node_id)
+                if block_devices.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have block device details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have block device details populated"
+                )
+
+            # Check if node has the disks data populated
+            try:
+                disks = NS._int.client.read("nodes/%s/Disks" % node_id)
+                # If disks have no child nodes, error out
+                if disks.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have disks details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have disks details populated"
+                )
+
+            # Check if node has networks details populated
+            try:
+                networks = NS._int.client.read("nodes/%s/Networks" % node_id)
+                if networks.leaves is None:
+                    raise AtomExecutionFailedError(
+                        "Node doesnt have network details populated"
+                    )
+            except etcd.EtcdKeyNotFound:
+                raise AtomExecutionFailedError(
+                    "Node doesnt have network details populated"
+                )
+
+        return True


### PR DESCRIPTION
Before starting the import/create cluster we should do
a pre-check for the validity and availability of node
entity and its details.

tendrl-bug-id: Tendrl/commons#550
Signed-off-by: Shubhendu <shtripat@redhat.com>