### PR TITLE
glusterfs_repo conf attribute related change

### DIFF
--- a/tendrl/commons/flows/create_cluster/gluster_help.py
+++ b/tendrl/commons/flows/create_cluster/gluster_help.py
@@ -28,7 +28,7 @@ def create_gluster(parameters):
 
     ret_val = plugin.setup_gluster_node(
         node_ips,
-        repo=NS.config.data['glusterfs_repo']
+        repo=NS.config.data.get('glusterfs_repo', None)
     )
     if ret_val is not True:
         raise FlowExecutionFailedError("Error setting up gluster node")

--- a/tendrl/commons/flows/expand_cluster/gluster_help.py
+++ b/tendrl/commons/flows/expand_cluster/gluster_help.py
@@ -28,7 +28,7 @@ def expand_gluster(parameters):
 
     ret_val = plugin.setup_gluster_node(
         node_ips,
-        repo=NS.config.data['glusterfs_repo']
+        repo=NS.config.data.get('glusterfs_repo', None)
     )
     if ret_val is not True:
         raise FlowExecutionFailedError("Error setting up gluster node")


### PR DESCRIPTION
If this attribute is not present in the conf file then
tendrl should pass None as the repo by default

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>