### PR TITLE
Make logging_socket_path, node_id and publisher_id optional

### DIFF
--- a/tendrl/commons/utils/ansible_module_runner.py
+++ b/tendrl/commons/utils/ansible_module_runner.py
@@ -31,26 +31,40 @@ class AnsibleRunner(object):
 
     """
 
-    def __init__(self, module_path, **kwargs):
+    def __init__(
+        self,
+        module_path,
+        publisher_id=None,
+        node_id=None,
+        socket_path=None,
+        **kwargs
+    ):
         self.module_path = modules.__path__[0] + "/" + module_path
+        self.socket_path = socket_path or NS.config.data['logging_socket_path']
+        self.publisher_id = publisher_id or NS.publisher_id
+        self.node_id = node_id or NS.node_context.node_id
         if not os.path.isfile(self.module_path):
             Event(
                 Message(
                     priority="debug",
-                    publisher=NS.publisher_id,
+                    publisher=self.publisher_id,
                     payload={"message": "Module path: %s does not exist" %
                                         self.module_path
-                             }
-                )
+                             },
+                    node_id=self.node_id
+                ),
+                socket_path=self.socket_path
             )
             raise AnsibleModuleNotFound(module_path=self.module_path)
         if kwargs == {}:
             Event(
                 Message(
                     priority="debug",
-                    publisher=NS.publisher_id,
-                    payload={"message": "Empty argument dictionary"}
-                )
+                    publisher=self.publisher_id,
+                    payload={"message": "Empty argument dictionary"},
+                    node_id=self.node_id
+                ),
+                socket_path=self.socket_path
             )
             raise ValueError
         else:
@@ -73,13 +87,15 @@ class AnsibleRunner(object):
             Event(
                 Message(
                     priority="debug",
-                    publisher=NS.publisher_id,
+                    publisher=self.publisher_id,
                     payload={"message": "Could not generate ansible "
                                         "executable data "
                                         "for module  : %s. Error: %s" %
                                         (self.module_path, str(e))
-                             }
-                )
+                             },
+                    node_id=self.node_id
+                ),
+                socket_path=self.socket_path
             )
             raise AnsibleExecutableGenerationFailed(
                 module_path=self.module_path,

--- a/tendrl/commons/utils/service.py
+++ b/tendrl/commons/utils/service.py
@@ -32,12 +32,18 @@ class Service(object):
         try:
             runner = ansible_module_runner.AnsibleRunner(
                 ANSIBLE_MODULE_PATH,
+                publisher_id=self.publisher_id,
+                node_id=self.node_id,
+                socket_path=self.socket_path,
                 **attr
             )
         except ansible_module_runner.AnsibleModuleNotFound:
             # Backward compat ansible<=2.2
             runner = ansible_module_runner.AnsibleRunner(
                 "core/" + ANSIBLE_MODULE_PATH,
+                publisher_id=self.publisher_id,
+                node_id=self.node_id,
+                socket_path=self.socket_path,
                 **attr
             )
         try:
@@ -54,7 +60,7 @@ class Service(object):
         except ansible_module_runner.AnsibleExecutableGenerationFailed as e:
             Event(
                 Message(
-                    priority="debug",
+                    priority="error",
                     publisher=self.publisher_id,
                     payload={"message": "Error switching the service: "
                                         "%s to %s state. Error: %s" %


### PR DESCRIPTION
1. tendrl's threshold notification handling collectd plugin
   uses the tendrl commons provided service utility to restart
   collectd after config is generated.
2. service utility uses ansible_module_runner for actions on service
Now the above said collectd plugin being an external integration, doesn't
have a namespace of its own and hence this pr facilitates optionally passing
logging_socket_path, node_id and publisher_id explicitly so that the
Message-Event framework can use these plugin passed values instead of
accessing them from NS which does not exist.

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>