### PR TITLE
Mark LocalStorage/Disk/:disk_id/ssd

### DIFF
--- a/tendrl/commons/objects/disk/__init__.py
+++ b/tendrl/commons/objects/disk/__init__.py
@@ -10,7 +10,7 @@ class Disk(objects.BaseObject):
                  device_files=None, device_number=None, bios_id=None,
                  geo_bios_edd=None, geo_logical=None, size=None, size_bios_edd=None,
                  geo_bios_legacy=None, config_status=None, partitions=None,
-                 *args, **kwargs):
+                 ssd=None, *args, **kwargs):
         super(Disk, self).__init__(*args, **kwargs)
         self.disk_id = disk_id
         self.hardware_id = hardware_id
@@ -36,6 +36,7 @@ class Disk(objects.BaseObject):
         self.geo_bios_legacy = geo_bios_legacy
         self.config_status = config_status
         self.partitions = partitions
+        self.ssd = ssd
         self.value = 'nodes/{0}/LocalStorage/Disks/{1}'
 
     def render(self):

--- a/tendrl/commons/objects/virtual_disk/__init__.py
+++ b/tendrl/commons/objects/virtual_disk/__init__.py
@@ -12,13 +12,13 @@ class VirtualDisk(Disk):
                  device_number=None, bios_id=None,
                  geo_bios_edd=None, geo_logical=None, size=None,
                  size_bios_edd=None, geo_bios_legacy=None,
-                 config_status=None, partitions=None,
+                 config_status=None, partitions=None, ssd=None,
                  *args, **kwargs):
         super(VirtualDisk, self).__init__(
             disk_id, hardware_id, disk_name, sysfs_id, sysfs_busid,
             sysfs_device_link, hardware_class, model, vendor, device,
             rmversion, serial_no, driver, driver_modules, device_files,
             device_number, bios_id, geo_bios_edd, geo_logical, size,
-            size_bios_edd, geo_bios_legacy, config_status, partitions,
+            size_bios_edd, geo_bios_legacy, config_status, partitions, ssd
             *args, **kwargs)
         self.value = 'nodes/{0}/LocalStorage/Virtio/{1}'


### PR DESCRIPTION
Tendrl marks the BlockDevices with ssd flag
Also required to mark raw disks with ssd flag

tendrl-bug-id: Tendrl/node-agent#489