### PR TITLE
Added `df` to the commands list

### DIFF
--- a/tendrl/commons/utils/cmd_utils.py
+++ b/tendrl/commons/utils/cmd_utils.py
@@ -20,7 +20,8 @@ SAFE_COMMAND_LIST = [
     "ping",
     "lvm",
     "gstatus",
-    "ls"
+    "ls",
+    "df"
 ]
 
 


### PR DESCRIPTION
This is required for figuring out the device path for OSDs

Signed-off-by: Shubhendu <shtripat@redhat.com>