### PR TITLE
Loading all instances of object (Issue #585)

### DIFF
--- a/tendrl/commons/objects/__init__.py
+++ b/tendrl/commons/objects/__init__.py
@@ -162,6 +162,23 @@ class BaseObject(object):
                 NS._int.wreconnect()
                 NS._int.wclient.write(item['key'], item['value'], quorum=True)
 
+    def load_all(self):
+        value = '/'.join(self.value.split('/')[:-1])
+        try:
+            etcd_resp = NS._int.client.read(value)
+        except (etcd.EtcdConnectionFailed, etcd.EtcdException) as ex:
+                    if type(ex) != etcd.EtcdKeyNotFound:
+                        NS._int.reconnect()
+                        etcd_resp = NS._int.client.read(value)
+                    else:
+                        return None
+        ins = []
+        for item in etcd_resp.leaves:
+            self.value = item.key
+            ins.append(self.load())
+        return ins
+
+
     def load(self):
         if not "Message" in self.__class__.__name__:
             try:

--- a/tendrl/commons/tests/utils/test_service.py
+++ b/tendrl/commons/tests/utils/test_service.py
@@ -32,6 +32,7 @@ def init():
     NS["node_context"] = maps.NamedDict()
     NS.node_context["node_id"] = 1
 
+
 def test_constructor():
     service = Service("Test_service","node_context",1,"/path/to/socket/",True)
     assert service.publisher_id == "node_context"
@@ -43,8 +44,8 @@ def test_constructor():
     assert service.node_id == 1
 
 
-    init()
 def test_start():
+    init()
     service = Service("Test_service")
     service.start()
     with patch.object(ansible_module_runner,'AnsibleRunner',ansible) as mock_ansible:
@@ -59,6 +60,7 @@ def test_start():
         assert ret[1] is True
         assert ret[0] == "test_msg"
 
+
 def test_stop():
     init()
     service = Service("Test_service")
@@ -67,6 +69,7 @@ def test_stop():
         mock_run.return_value = ansible_run(False)
         ret = service.stop()
         assert ret[1] is True
+
 
 def test_reload():
     init()


### PR DESCRIPTION
Load_all() function to load all instances of object
Returns List of instances that is loaded
tendrl-bug-id: Tendrl/commons#585