### PR TITLE
Check pre-existing provisioner while importing a gluster cluster

### DIFF
--- a/tendrl/commons/flows/create_cluster/utils.py
+++ b/tendrl/commons/flows/create_cluster/utils.py
@@ -66,7 +66,11 @@ def install_gdeploy():
             **attributes
         )
     try:
-        runner.run()
+        result, err = runner.run()
+        if result['failed']:
+            raise FlowExecutionFailedError(
+                "Failed to install gdeploy. %s" % result['msg']
+            )
     except ansible_module_runner.AnsibleExecutableGenerationFailed:
         raise FlowExecutionFailedError(
             "Failed to install gdeploy"
@@ -101,7 +105,11 @@ def install_python_gdeploy():
             **attributes
         )
     try:
-        runner.run()
+        result, err = runner.run()
+        if result['failed']:
+            raise FlowExecutionFailedError(
+                "Failed to install python-gdeploy. %s" % result['msg']
+            )
     except ansible_module_runner.AnsibleExecutableGenerationFailed:
         raise FlowExecutionFailedError(
             "Failed to install python-gdeploy"

--- a/tendrl/commons/objects/node_context/__init__.py
+++ b/tendrl/commons/objects/node_context/__init__.py
@@ -125,5 +125,5 @@ class NodeContext(objects.BaseObject):
             return None
 
     def render(self):
-        self.value = self.value.format(NS.node_context.node_id)
+        self.value = self.value.format(self.node_id or NS.node_context.node_id)
         return super(NodeContext, self).render()


### PR DESCRIPTION
If there is already a node marked as gluster provisioner with
tag `provisioner/gluster` mark the same as provisioner while
import cluster flow.

tendrl-bug-id: Tendrl/gluster-integration#315
Signed-off-by: Shubhendu <shtripat@redhat.com>