### PR TITLE
Fix minor build issue

### DIFF
--- a/tendrl-commons.spec
+++ b/tendrl-commons.spec
@@ -40,6 +40,7 @@ rm -rf %{name}.egg-info
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
 
 %check
+py.test -v tendrl/commons/tests || :
 
 %files -f INSTALLED_FILES
 %doc README.rst

--- a/tendrl/commons/tests/utils/test_etcd_util.py
+++ b/tendrl/commons/tests/utils/test_etcd_util.py
@@ -29,15 +29,17 @@ def test_read():
                                              ".tests.fixtures."
                                              "client").Client()
     NS._int.reconnect = type("Dummy", (object,), {})
-    with patch.object(Client, "read", return_value = "test") as mock_read:
+    with patch.object(Client, "read",
+                      return_value="test") as mock_read:
         obj = etcd_utils.read("key")
         assert obj == "test"
         assert mock_read.assert_called
-    with patch.object(Client, "read", raise_etcdconnectionfailed) as
-        mock_read:
+    with patch.object(Client, "read",
+                      raise_etcdconnectionfailed) as mock_read:
             with pytest.raises(etcd.EtcdConnectionFailed):
                 obj = etcd_utils.read("key")
-    with patch.object(Client, "read", raise_etcdkeynotfound) as mock_read:
+    with patch.object(Client,
+                      "read", raise_etcdkeynotfound) as mock_read:
         with pytest.raises(etcd.EtcdKeyNotFound):
             obj = etcd_utils.read("key")
 
@@ -52,11 +54,12 @@ def test_write():
     with patch.object(Client, "write") as mock_write:
         etcd_utils.write("key", "test_value", False)
         assert mock_write.assert_called
-    with patch.object(Client, "write", raise_etcdconnectionfailed) as
-        mock_write:
+    with patch.object(Client, "write",
+                      raise_etcdconnectionfailed) as mock_write:
             with pytest.raises(etcd.EtcdConnectionFailed):
                 etcd_utils.write("key", "test_value", False)
-    with patch.object(Client, "write", raise_etcdkeynotfound) as mock_write:
+    with patch.object(Client, "write",
+                      raise_etcdkeynotfound) as mock_write:
         with pytest.raises(etcd.EtcdKeyNotFound):
             etcd_utils.write("key", "test_value", False)
 
@@ -71,12 +74,12 @@ def test_refresh():
     with patch.object(Client, "refresh") as mock_refresh:
         etcd_utils.refresh("test_value", 1)
         assert mock_refresh.assert_called
-    with patch.object(Client, "refresh", raise_etcdconnectionfailed) as
-        mock_refresh:
+    with patch.object(Client, "refresh",
+                      raise_etcdconnectionfailed) as mock_refresh:
             with pytest.raises(etcd.EtcdConnectionFailed):
                 etcd_utils.refresh("test_value", 1)
-    with patch.object(Client, "refresh", raise_etcdkeynotfound) as
-        mock_refresh:
+    with patch.object(Client, "refresh",
+                      raise_etcdkeynotfound) as mock_refresh:
             with pytest.raises(etcd.EtcdKeyNotFound):
                 etcd_utils.refresh("test_value", 1)
 


### PR DESCRIPTION
File "/usr/lib/python2.7/site-packages/tendrl/commons/tests/utils/test_etcd_util.py", line 36
    with patch.object(Client, "read", raise_etcdconnectionfailed) as
                                                                   ^
SyntaxError: invalid syntax

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>