### PR TITLE
Packaging: snapshot srpm version with timestamp and shortcommit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,12 @@ VERSION := $(shell PYTHONPATH=. python -c \
 RELEASE=1
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
-GIT_RELEASE := $(shell git describe --tags --match 'v*' \
-                 | sed 's/^v//' \
-                 | sed 's/^[^-]*-//' \
-                 | sed 's/-.*//')
 
 all: srpm
 
 clean:
 	rm -rf dist/
-	rm -f $(NAME)-$(VERSION).tar.gz
+	rm -rf $(NAME)-$(VERSION).tar.gz
 	rm -rf $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm
 
 dist:
@@ -25,18 +21,12 @@ srpm: dist
 	fedpkg --dist epel7 srpm
 
 rpm: dist
-	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-*.src.rpm --resultdir=. --define "dist .el7"
 
 gitversion:
 	# Set version and release to the latest values from Git
-	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
-	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
-	sed -i version.py \
-	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
-	sed -i tendrl-commons.spec \
-	  -e "s/^Version: .*/Version: $(VERSION)/"
-	sed -i tendrl-commons.spec \
-	  -e "s/^Release: .*/Release: $(RELEASE)/"
+	sed -i $(NAME).spec \
+	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT)"
 
 snapshot: gitversion srpm
 

--- a/tendrl-commons.spec
+++ b/tendrl-commons.spec
@@ -25,7 +25,7 @@ Requires: python-gevent
 
 
 %description
-Common lib for Tendrl sds integrations and node-agent
+Common library for tendrl
 
 %prep
 %setup


### PR DESCRIPTION
Update makefile for snapshot srpm version to have timestamp
and shortcommit

tendrl-bug-id: Tendrl/commons#662
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>