### PR TITLE
Update tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 
 [testenv:codecov]
 commands = 
-    python -m pytest --ignore=tendrl/commons/tests/fixme --cov=tendrl tendrl/commons/tests
+    {envpython} -m pytest --ignore=tendrl/commons/tests/fixme --cov=tendrl tendrl/commons/tests
     codecov -e TOXENV
 
 # Runs PEP8 checks on the source code via flake8 tool

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,10 @@ deps =
     mock
     coverage
     pytest-cov
-    codecov
-
-[testenv:codecov]
+    codecov: codecov
 commands = 
     {envpython} -m pytest --ignore=tendrl/commons/tests/fixme --cov=tendrl {posargs:tendrl/commons/tests}
-    codecov -e TOXENV
+    codecov: codecov -e TOXENV
 
 # Runs PEP8 checks on the source code via flake8 tool
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 
 [testenv:codecov]
 commands = 
-    {envpython} -m pytest --ignore=tendrl/commons/tests/fixme --cov=tendrl tendrl/commons/tests
+    {envpython} -m pytest --ignore=tendrl/commons/tests/fixme --cov=tendrl {posargs:tendrl/commons/tests}
     codecov -e TOXENV
 
 # Runs PEP8 checks on the source code via flake8 tool


### PR DESCRIPTION
Changes in this pull request makes it possible to run unit tests via tox from command line again:

```
$ tox -e py27
```

while keeping the `cover` test environment working without changes (this is used in Travis CI).

Moreover, it's also possible to pass arguments to pytest via tox like this:

```
$ tox -e py27 -- tendrl/commons/tests/test_message.py -v
```

which will run pytest in tox maintained virtualenv with given agruments, so that it's easier to run just particular test cases or to run pytest in verbose mode (as shown in the example above).