### PR TITLE
Mark the node which picks the import cluster job as provisioner

### DIFF
--- a/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
+++ b/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
@@ -152,6 +152,8 @@ class ImportCluster(objects.BaseAtom):
                             )
                         )
                     else:
+                        # TODO(shtripat) ceph-installer is auto detected and provisioner/$integration_id
+                        # tag is set , below is not required for ceph
                         NS.node_context.tags += ['provisioner/%s' % integration_id]
                         NS.node_context.save()
 

--- a/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
+++ b/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
@@ -151,6 +151,9 @@ class ImportCluster(objects.BaseAtom):
                                 }
                             )
                         )
+                    else:
+                        NS.node_context.tags += ['provisioner/%s' % integration_id]
+                        NS.node_context.save()
 
             if "ceph" in sds_name.lower():
                 node_context = NS.node_context.load()


### PR DESCRIPTION
The first node which picks the import cluster job would be marked
with tag `provisioner/gluster`. Later while syncing the cluster
details this tag would be used for creating aggregated sync job.

tendrl-bug-id: Tendrl/gluster-integration#359
Signed-off-by: Shubhendu <shtripat@redhat.com>