### PR TITLE
Update python-ruamel-yaml dependency name

### DIFF
--- a/tendrl-commons.spec
+++ b/tendrl-commons.spec
@@ -18,7 +18,7 @@ Requires: python-maps
 Requires: python-dateutil
 Requires: python-etcd
 Requires: python-six
-Requires: python-ruamel-yaml
+Requires: python2-ruamel-yaml
 Requires: pytz
 Requires: python-psutil
 Requires: python-gevent


### PR DESCRIPTION
python-ruamel-yaml is now available in epel7 as python2-ruamel-yaml
This patch will rename the dependency package name so that it will
come from epel7 repo.

tendrl-bug-id: Tendrl/commons#705
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>