### PR TITLE
Changed the minimum version required for glusterfs

### DIFF
--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -3,7 +3,7 @@ namespace.tendrl:
   supported_sds:
    - ceph
    - gluster
-  min_reqd_gluster_ver: 3.9.0
+  min_reqd_gluster_ver: 3.12.0
   min_reqd_ceph_ver: 10.2.5
   ceph_provisioner: CephInstallerPlugin
   gluster_provisioner: GdeployPlugin


### PR DESCRIPTION
tendrl-bug-id: Tendrl/gluster-integration#380
Signed-off-by: Shubhendu <shtripat@redhat.com>