### PR TITLE
Include "gluster-eventsapi" cmd in safe command list.

### DIFF
--- a/tendrl/commons/utils/cmd_utils.py
+++ b/tendrl/commons/utils/cmd_utils.py
@@ -22,7 +22,8 @@ SAFE_COMMAND_LIST = [
     "lvm",
     "gstatus",
     "ls",
-    "df"
+    "df",
+    "gluster-eventsapi"
 ]
 
 


### PR DESCRIPTION
This command is needed by gluster integration to handle gluster native events

tendrl-bug-id: Tendrl/specifications#180
tendrl-bug-id: Tendrl/gluster-integration#361
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>