### PR TITLE
Added ttl for node status attribute.

### DIFF
--- a/tendrl/commons/objects/cluster_node_context/__init__.py
+++ b/tendrl/commons/objects/cluster_node_context/__init__.py
@@ -1,15 +1,18 @@
 from tendrl.commons import objects
+from tendrl.commons.utils import etcd_utils
+from tendrl.commons.utils import time_utils
 
 
 class ClusterNodeContext(objects.BaseObject):
 
-    def __init__(self, node_id=None, fqdn=None,
+    def __init__(self, node_id=None, fqdn=None, updated_at=None,
                  tags=None, status=None, sync_status=None,
                  last_sync=None, *args, **kwargs):
         super(ClusterNodeContext, self).__init__(*args, **kwargs)
         _node_context = NS.node_context.load()
         self.node_id = node_id or _node_context.node_id
         self.fqdn = fqdn or _node_context.fqdn
+        self.updated_at = updated_at or str(time_utils.now())
         self.tags = tags or _node_context.tags
         self.status = status or _node_context.status
         self.sync_status = sync_status or _node_context.sync_status
@@ -20,3 +23,9 @@ class ClusterNodeContext(objects.BaseObject):
         self.value = self.value.format(NS.tendrl_context.integration_id,
                                        self.node_id)
         return super(ClusterNodeContext, self).render()
+
+    def save(self, update=True, ttl=None):
+        super(ClusterNodeContext, self).save(update)
+        status = self.value + "/status"
+        if ttl:
+            etcd_utils.refresh(status, ttl)

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -992,6 +992,9 @@ namespace.tendrl:
         node_id:
           help: "Tendrl ID for the managed node"
           type: String
+        updated_at:
+          help: "last updated time of node context"
+          type: String
         tags:
           help: "The tags associated with this node"
           type: List
@@ -1010,6 +1013,9 @@ namespace.tendrl:
           type: String
         node_id:
           help: "Tendrl ID for the managed node"
+          type: String
+        updated_at:
+          help: "last updated time of node context"
           type: String
         tags:
           help: "The tags associated with this node"


### PR DESCRIPTION
This patch adds heartbeat object which will be updated
during node sync. If the node goes down due to any
reason, the heart beat object will vanish after some
time. Thus API layer can get to know that node is down
and mark it accordingly.

tendrl-bug-id: Tendrl/node-agent#592
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>