### PR TITLE
Modified to wait for import jobs to complete on other nodes

### DIFF
--- a/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
+++ b/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
@@ -164,11 +164,11 @@ class ImportCluster(objects.BaseAtom):
                         if child_job.status != "finished":
                             finished = False
                             break
-                    if not finished:
+                    if finished:
+                        break
+                    else:
                         loop_count += 1
                         continue
-                    else:
-                        break
 
         except Exception as ex:
             # For traceback


### PR DESCRIPTION
The parent import cluster job should be marked as finished only
when other nodes report import job as completed. Modified the code
to wait for no of nodes * 1 minutes for other jobs to complete and
then only mark the parent job as complete.

tendrl-bug-id: Tendrl/commons#710
Signed-off-by: Shubhendu <shtripat@redhat.com>