### PR TITLE
Modified the wait time per node for completing the import cluster

### DIFF
--- a/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
+++ b/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
@@ -139,8 +139,8 @@ class ImportCluster(objects.BaseAtom):
                 )
                 parent_job = Job(job_id=self.parameters['job_id']).load()
                 loop_count = 0
-                # Wait for (no of nodes) * 1 minutes for import to complete
-                wait_count = (len(node_list) - 1) * 6
+                # Wait for (no of nodes) * 2 minutes for import to complete
+                wait_count = (len(node_list) - 1) * 12
                 while True:
                     if loop_count >= wait_count:
                         Event(


### PR DESCRIPTION
As the collectd configuration might take more time, modified the
wait time for individual node's import to complete to 2 minutes.

Signed-off-by: Shubhendu <shtripat@redhat.com>