### PR TITLE
Add configure_monitoring

### DIFF
--- a/tendrl/commons/flows/configure_monitoring/__init__.py
+++ b/tendrl/commons/flows/configure_monitoring/__init__.py
@@ -1,0 +1,16 @@
+from tendrl.commons import flows
+from tendrl.commons.flows.exceptions import FlowExecutionFailedError
+
+
+class ConfigureMonitoring(flows.BaseFlow):
+    def __init__(self, *args, **kwargs):
+        super(ConfigureMonitoring, self).__init__(*args, **kwargs)
+
+    def run(self):
+        _cluster = NS.tendrl.objects.Cluster(
+            integration_id=NS.tendrl_context.integration_id
+        ).load()
+        if _cluster.is_managed != "yes":
+            raise FlowExecutionFailedError('Cluster is not managed')
+        self.parameters['Service.name'] = 'collectd'
+        super(ConfigureMonitoring, self).run()

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -21,6 +21,24 @@ namespace.tendrl:
     ceph-provisioner: "provisioner/ceph"
     ceph-installer: "provisioner/ceph"
   flows:
+    ConfigureMonitoring:
+      tags:
+        - "tendrl/node_$NodeContext.node_id"
+      atoms:
+        - tendrl.objects.Cluster.atoms.ConfigureMonitoring
+      help: "(Re)Configure Monitoring"
+      enabled: true
+      inputs:
+        mandatory:
+          - TendrlContext.integration_id
+      pre_run:
+        - tendrl.objects.Cluster.atoms.CheckClusterAvailable
+      post_run:
+        - tendrl.objects.Service.atoms.CheckServiceStatus
+      run: tendrl.flows.ConfigureMonitoring
+      type: Create
+      uuid: 6f94a48a-05d7-408m-b400-e27827q4eacd
+      version: 1
     CreateCluster:
       tags: 
         - "provisioner/$TendrlContext.sds_name"


### PR DESCRIPTION
This is to handle cases of provisioner disconnects and
old provisioner back in life.

tendrl-bug-id: Tendrl/commons#749
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>