### PR TITLE
Enable tendrl-gluster-integration service during import

### DIFF
--- a/tendrl/commons/flows/import_cluster/gluster_help.py
+++ b/tendrl/commons/flows/import_cluster/gluster_help.py
@@ -146,7 +146,12 @@ def import_gluster(parameters):
         )
     )
     os.chmod(_gluster_integration_conf_file_path, 0o640)
+
+    if NS.config.data['package_source_type'] == 'rpm':
+        command = "systemctl enable tendrl-gluster-integration"
+        subprocess.Popen(command.split())
     subprocess.Popen(_cmd.split())
+
     return True
 
 


### PR DESCRIPTION
Currently tendrl-gluster-integration service is not
enabled during import. Because of this it doesnt start
automatically on reboot. This patch adds code to enable
the service during import.

tendrl-bug-id: Tendrl/gluster-integration#294
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>