### PR TITLE
Enable tendrl-gluster-integration service during import

### DIFF
--- a/tendrl/commons/flows/import_cluster/gluster_help.py
+++ b/tendrl/commons/flows/import_cluster/gluster_help.py
@@ -9,6 +9,7 @@ from tendrl.commons.event import Event
 from tendrl.commons.message import Message
 from tendrl.commons.objects.job import Job
 from tendrl.commons.utils import ansible_module_runner
+from tendrl.commons.utils import cmd_utils
 from tendrl.commons.utils import log_utils
 
 
@@ -120,9 +121,13 @@ def import_gluster(parameters):
     etcd_ca_cert_file = NS.config.data.get("etcd_ca_cert_file")
     etcd_cert_file = NS.config.data.get("etcd_cert_file")
     etcd_key_file = NS.config.data.get("etcd_key_file")
-    if etcd_ca_cert_file and str(etcd_ca_cert_file) != "" \
-        and etcd_cert_file and str(etcd_cert_file) != "" \
-        and etcd_key_file and str(etcd_key_file) != "":
+    if etcd_ca_cert_file and str(
+            etcd_ca_cert_file
+    ) != "" and etcd_cert_file and str(
+        etcd_cert_file
+    ) != "" and etcd_key_file and str(
+        etcd_key_file
+    ) != "":
         config_data.update({
             "etcd_ca_cert_file": NS.config.data['etcd_ca_cert_file'],
             "etcd_cert_file": NS.config.data['etcd_cert_file'],
@@ -148,9 +153,41 @@ def import_gluster(parameters):
     os.chmod(_gluster_integration_conf_file_path, 0o640)
 
     if NS.config.data['package_source_type'] == 'rpm':
-        command = "systemctl enable tendrl-gluster-integration"
-        subprocess.Popen(command.split())
-    subprocess.Popen(_cmd.split())
+        command = cmd_utils.Command(
+            "systemctl enable tendrl-gluster-integration"
+        )
+        err, out, rc = command.run()
+        if err:
+            Event(
+                Message(
+                    job_id=parameters['job_id'],
+                    flow_id=parameters['flow_id'],
+                    priority="error",
+                    publisher=NS.publisher_id,
+                    payload={
+                        "message": "Could not enable gluster-integration"
+                        " service. Error: %s" % err
+                    }
+                )
+            )
+            return False
+
+    cmd = cmd_utils.Command(_cmd)
+    err, out, rc = cmd.run()
+    if err:
+        Event(
+            Message(
+                job_id=parameters['job_id'],
+                flow_id=parameters['flow_id'],
+                priority="error",
+                publisher=NS.publisher_id,
+                payload={
+                    "message": "Could not start gluster-integration"
+                    " service. Error: %s" % err
+                }
+            )
+        )
+        return False
 
     return True
 


### PR DESCRIPTION
Currently tendrl-gluster-integration service is not
enabled during import. Because of this it doesnt start
automatically on reboot. This patch adds code to enable
the service during import.

tendrl-bug-id: Tendrl/gluster-integration#294
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>