### PR TITLE
Removing create new dashboard function from import cluster flow

### DIFF
--- a/tendrl/commons/flows/import_cluster/gluster_help.py
+++ b/tendrl/commons/flows/import_cluster/gluster_help.py
@@ -189,33 +189,3 @@ def import_gluster(parameters):
         return False
 
     return True
-
-
-def update_dashboard(parameters):
-    integration_id = parameters['TendrlContext.integration_id']
-    _job_id = str(uuid.uuid4())
-    _params = {
-        "TendrlContext.integration_id": integration_id
-    }
-    _job_payload = {
-        "tags": ["tendrl/integration/monitoring"],
-        "run": "monitoring.flows.NewClusterDashboard",
-        "status": "new",
-        "parameters": _params,
-        "parent": parameters['job_id'],
-        "type": "monitoring"
-    }
-    Job(
-        job_id=_job_id,
-        status="new",
-        payload=_job_payload
-    ).save()
-    log_utils.log(
-        "debug",
-        NS.publisher_id,
-        {
-            'message': "Job (job_id: %s) created to "
-                       "create monitoring dashboard" %
-                       _job_id
-        }
-    )

--- a/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
+++ b/tendrl/commons/objects/cluster/atoms/import_cluster/__init__.py
@@ -6,7 +6,6 @@ from tendrl.commons.event import Event
 from tendrl.commons.flows.create_cluster import utils as create_cluster_utils
 from tendrl.commons.flows.exceptions import FlowExecutionFailedError
 from tendrl.commons.flows.import_cluster.gluster_help import import_gluster
-from tendrl.commons.flows.import_cluster.gluster_help import update_dashboard
 from tendrl.commons.message import ExceptionMessage
 from tendrl.commons.message import Message
 from tendrl.commons import objects
@@ -188,7 +187,6 @@ class ImportCluster(objects.BaseAtom):
             # raising exception to mark job as failed
             raise ex
         finally:
-            update_dashboard(self.parameters)
             # release lock
             create_cluster_utils.release_node_lock(self.parameters)
 


### PR DESCRIPTION
Refresh dashboard in monitoring_integration will takecare of
creating or updating the dashboards.

Tendrl-bugid: Tendrl/commons#778

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>