### PR TITLE
Svc connection clearing  alert is not matched with warning alert

### DIFF
--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -786,7 +786,7 @@ namespace.tendrl:
           - rebalance_status_update_failed
           - georep_checkpoint_completed
           - quorum
-          - svc_connecion
+          - svc_connection
           - ec_min_bricks_up
           - afr_quorum_state
           - afr_subvol_state


### PR DESCRIPTION
tendrl-bugid: Tendrl/commons#800

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>