### PR TITLE
Added flow ExpandCluserWithDetectedPeers

### DIFF
--- a/tendrl/commons/flows/expand_cluster_with_detected_peers/__init__.py
+++ b/tendrl/commons/flows/expand_cluster_with_detected_peers/__init__.py
@@ -1,5 +1,8 @@
 import time
+import json
 import uuid
+
+import etcd
 
 from tendrl.commons import flows
 from tendrl.commons.flows.exceptions import FlowExecutionFailedError

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -98,11 +98,10 @@ namespace.tendrl:
     ExpandClusterWithDetectedPeers:
       tags:
         - "provisioner/$TendrlContext.integration_id"
-      help: "expanding an existing cluster with newly detected peers"
+      help: "Expand an existing cluster with newly detected peers"
       enabled: true
       inputs:
         mandatory:
-          - "Node[]"
           - TendrlContext.integration_id
       run: tendrl.flows.ExpandClusterWithDetectedPeers
       type: Update

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -95,6 +95,19 @@ namespace.tendrl:
       type: Update
       uuid: 2f94a48a-05d7-408c-b400-e27827f4efed
       version: 1
+    ExpandClusterWithDetectedPeers:
+      tags:
+        - "provisioner/$TendrlContext.integration_id"
+      help: "expanding an existing cluster with newly detected peers"
+      enabled: true
+      inputs:
+        mandatory:
+          - "Node[]"
+          - TendrlContext.integration_id
+      run: tendrl.flows.ExpandClusterWithDetectedPeers
+      type: Update
+      uuid: 2f94a48a-05d7-408c-b400-27827f4edcae
+      version: 1
 
   objects:
     Cluster:


### PR DESCRIPTION
This flow would be invoked from tendrl-node-agent on the additionally
detected new peers of the cluster. New nodes would be provisioned with
monitoring etc and imported into the cluster in tendrl system.

tendrl-bug-id: Tendrl/commons#805
Signed-off-by: Shubhendu <shtripat@redhat.com>