### PR TITLE
Directory is empty then load_all function should return empty list

### DIFF
--- a/tendrl/commons/objects/__init__.py
+++ b/tendrl/commons/objects/__init__.py
@@ -169,8 +169,14 @@ class BaseObject(object):
                         return None
         ins = []
         for item in etcd_resp.leaves:
-            self.value = item.key
-            ins.append(self.load())
+            # When directory is not empty then NS._int.client.read(key)
+            # will return key + directory id as new key. If directory is
+            # empty then it will return key only. When directory is
+            # not present then it will raise EtcdKeyNotFound
+            if item.key.strip("/") != value.strip("/"):
+                # if dir is empty then item.key and value is same
+                self.value = item.key
+                ins.append(self.load())
         return ins
 
     @thread_safe


### PR DESCRIPTION
tendrl-bug-id: Tendrl/commons#850
tendrl-bug-id: Tendrl/gluster-integration#576

Signed-off-by: GowthamShanmugamsundaram <gshanmug@redhat.com>