### PR TITLE
Added logic to remove current node from nodes list for expansion

### DIFF
--- a/tendrl/commons/flows/expand_cluster_with_detected_peers/__init__.py
+++ b/tendrl/commons/flows/expand_cluster_with_detected_peers/__init__.py
@@ -76,6 +76,9 @@ class ExpandClusterWithDetectedPeers(flows.BaseFlow):
 
         job_ids = []
         new_peers = []
+        # Remove the current node from list as its already participating
+        # in cluster for sure
+        node_ids.remove(NS.node_context.node_id)
         for node_id in node_ids:
             _cnc = NS.tendrl.objects.ClusterNodeContext(
                 node_id=node_id


### PR DESCRIPTION
The expand cluster job is targeted at provisioner node which for
sure would be participating in cluster by the time expand cluster
gets executed. Remove the current node from the nodes list while
figuring out where all to execute import cluster for new nodes.

Signed-off-by: Shubhendu <shtripat@redhat.com>