### PR TITLE
Allow un-manage cluster even if there is a failed import cluster earlier

### DIFF
--- a/tendrl/commons/flows/unmanage_cluster/__init__.py
+++ b/tendrl/commons/flows/unmanage_cluster/__init__.py
@@ -18,10 +18,10 @@ class UnmanageCluster(flows.BaseFlow):
                     raise FlowExecutionFailedError(
                         "Cluster is already in un-managed state"
                     )
-        if ('job_id' in _cluster.locked_by and
-            _cluster.locked_by['job_id'] != "") or \
-            (_cluster.current_job['status'] == 'in_progress' and
-             _cluster.status in ['importing', 'unmanaging', 'expanding']):
+        if _cluster.current_job['status'] == 'in_progress' and \
+            ('job_id' in _cluster.locked_by and
+            _cluster.locked_by['job_id'] != "") and \
+            (_cluster.status in ['importing', 'unmanaging', 'expanding']):
             raise FlowExecutionFailedError(
                 "Another job in progress for cluster."
                 " Please wait till the job finishes "

--- a/tendrl/commons/flows/unmanage_cluster/__init__.py
+++ b/tendrl/commons/flows/unmanage_cluster/__init__.py
@@ -20,8 +20,8 @@ class UnmanageCluster(flows.BaseFlow):
                     )
         if _cluster.current_job['status'] == 'in_progress' and \
             ('job_id' in _cluster.locked_by and
-            _cluster.locked_by['job_id'] != "") and \
-            (_cluster.status in ['importing', 'unmanaging', 'expanding']):
+              _cluster.locked_by['job_id'] != "") and \
+              (_cluster.status in ['importing', 'unmanaging', 'expanding']):
             raise FlowExecutionFailedError(
                 "Another job in progress for cluster."
                 " Please wait till the job finishes "

--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -92,7 +92,6 @@ namespace.tendrl:
           - TendrlContext.integration_id
       pre_run:
         - tendrl.objects.Cluster.atoms.CheckClusterNodesUp
-        - tendrl.objects.Cluster.atoms.IsClusterManaged
       post_run:
         - tendrl.objects.Cluster.atoms.IsClusterImportReady
       run: tendrl.flows.UnmanageCluster


### PR DESCRIPTION
tendrl-bug-id: Tendrl/commons#895
Signed-off-by: Shubhendu <shtripat@redhat.com>