### PR TITLE
Added a flag delete_telemetry_data for flow UnmanageCluster

### DIFF
--- a/tendrl/commons/objects/definition/master.yaml
+++ b/tendrl/commons/objects/definition/master.yaml
@@ -94,6 +94,8 @@ namespace.tendrl:
       inputs:
         mandatory:
           - TendrlContext.integration_id
+        optional:
+          - Cluster.delete_telemetry_data
       pre_run:
         - tendrl.objects.Cluster.atoms.CheckClusterNodesUp
       post_run:


### PR DESCRIPTION
Based on this flag passed with value `yes`, the monitoring data
maintained for the cluster under carbon would be deleted. If flag
is not passed or passed as `no`, the data would be archived in
the pre-defined path.

bugzilla: 1582375
tendrl-bug-id: Tendrl/commons#819
Signed-off-by: Shubhendu <shtripat@redhat.com>