### PR TITLE
Proposed changes to is_tendrl_node_managed

### DIFF
--- a/tendrl/commons/objects/node/atoms/is_node_tendrl_managed/__init__.py
+++ b/tendrl/commons/objects/node/atoms/is_node_tendrl_managed/__init__.py
@@ -5,6 +5,60 @@ from tendrl.commons.objects import AtomExecutionFailedError
 from tendrl.commons.utils import etcd_utils
 
 
+def os_check(node_id):
+    try:
+        os_details = etcd_utils.read("nodes/%s/Os" % node_id)
+        if os_details.leaves is None:
+            raise AtomExecutionFailedError(
+                "Node doesnt have OS details populated"
+            )
+    except etcd.EtcdKeyNotFound:
+        raise AtomExecutionFailedError(
+            "Node doesnt have OS details populated"
+        )
+
+
+def cpu_check(node_id):
+    try:
+        cpu_details = etcd_utils.read("nodes/%s/Cpu" % node_id)
+        if cpu_details.leaves is None:
+            raise AtomExecutionFailedError(
+                "Node doesnt have CPU details populated"
+            )
+    except etcd.EtcdKeyNotFound:
+        raise AtomExecutionFailedError(
+            "Node doesnt have CPU details populated"
+        )
+
+
+def memory_check(node_id):
+    try:
+        memory_details = etcd_utils.read(
+            "nodes/%s/Memory" % node_id
+        )
+        if memory_details.leaves is None:
+            raise AtomExecutionFailedError(
+                "Node doesnt have Memory details populated"
+            )
+    except etcd.EtcdKeyNotFound:
+        raise AtomExecutionFailedError(
+            "Node doesnt have Memory details populated"
+        )
+
+
+def network_check(node_id):
+    try:
+        networks = etcd_utils.read("nodes/%s/Networks" % node_id)
+        if networks.leaves is None:
+            raise AtomExecutionFailedError(
+                "Node doesnt have network details populated"
+            )
+    except etcd.EtcdKeyNotFound:
+        raise AtomExecutionFailedError(
+            "Node doesnt have network details populated"
+        )
+
+
 class IsNodeTendrlManaged(objects.BaseAtom):
     def __init__(self, *args, **kwargs):
         super(IsNodeTendrlManaged, self).__init__(*args, **kwargs)
@@ -15,54 +69,17 @@ class IsNodeTendrlManaged(objects.BaseAtom):
             raise AtomExecutionFailedError("Node[] cannot be empty")
 
         for node_id in node_ids:
+
             # Check if node has the OS details populated
-            try:
-                os_details = etcd_utils.read("nodes/%s/Os" % node_id)
-                if os_details.leaves is None:
-                    raise AtomExecutionFailedError(
-                        "Node doesnt have OS details populated"
-                    )
-            except etcd.EtcdKeyNotFound:
-                raise AtomExecutionFailedError(
-                    "Node doesnt have OS details populated"
-                )
+            os_check(node_id)
 
             # Check if node has the CPU details populated
-            try:
-                cpu_details = etcd_utils.read("nodes/%s/Cpu" % node_id)
-                if cpu_details.leaves is None:
-                    raise AtomExecutionFailedError(
-                        "Node doesnt have CPU details populated"
-                    )
-            except etcd.EtcdKeyNotFound:
-                raise AtomExecutionFailedError(
-                    "Node doesnt have CPU details populated"
-                )
+            cpu_check(node_id)
 
             # Check if node has the Memory populated
-            try:
-                memory_details = etcd_utils.read(
-                    "nodes/%s/Memory" % node_id
-                )
-                if memory_details.leaves is None:
-                    raise AtomExecutionFailedError(
-                        "Node doesnt have Memory details populated"
-                    )
-            except etcd.EtcdKeyNotFound:
-                raise AtomExecutionFailedError(
-                    "Node doesnt have Memory details populated"
-                )
+            memory_check(node_id)
 
             # Check if node has networks details populated
-            try:
-                networks = etcd_utils.read("nodes/%s/Networks" % node_id)
-                if networks.leaves is None:
-                    raise AtomExecutionFailedError(
-                        "Node doesnt have network details populated"
-                    )
-            except etcd.EtcdKeyNotFound:
-                raise AtomExecutionFailedError(
-                    "Node doesnt have network details populated"
-                )
+            network_check(node_id)
 
         return True

--- a/tendrl/commons/tests/objects/node/atoms/is_node_tendrl_managed/test_is_node_tendrl_managed.py
+++ b/tendrl/commons/tests/objects/node/atoms/is_node_tendrl_managed/test_is_node_tendrl_managed.py
@@ -1,6 +1,5 @@
 import __builtin__
 import etcd
-from etcd import Client
 import maps
 from mock import patch
 import pytest
@@ -8,35 +7,16 @@ import pytest
 
 from tendrl.commons.objects import AtomExecutionFailedError
 from tendrl.commons.objects.node.atoms.is_node_tendrl_managed import \
-    IsNodeTendrlManaged
+    IsNodeTendrlManaged, os_check, cpu_check, memory_check, network_check # noqa
 from tendrl.commons.utils import etcd_utils
 
 
 def read(*args, **kwargs):
-    if args:
-        if args[0] == "nodes/Test_node/Os":
-            raise etcd.EtcdKeyNotFound
-    else:
-        return None
-
-
-def test_constructor():
-    IsNodeTendrlManaged()
+    raise etcd.EtcdKeyNotFound
 
 
 @patch.object(etcd, "Client")
-@patch.object(Client, "read")
-@patch.object(etcd_utils, "read")
-def test_run(mock_etcd_read, mock_read, mock_client):
-    mock_read.return_value = read()
-    mock_client.return_value = etcd.Client()
-    obj = IsNodeTendrlManaged()
-    assert obj.parameters is not None
-    obj.parameters = maps.NamedDict()
-    obj.parameters["Node[]"] = []
-    with pytest.raises(AtomExecutionFailedError):
-        obj.run()
-    obj.parameters["Node[]"] = ["Test_node"]
+def test_run(mock_client):
     setattr(__builtin__, "NS", maps.NamedDict())
     setattr(NS, "_int", maps.NamedDict())
     NS._int.etcd_kwargs = {
@@ -44,12 +24,24 @@ def test_run(mock_etcd_read, mock_read, mock_client):
         'host': 2,
         'allow_reconnect': True}
     NS._int.client = etcd.Client(**NS._int.etcd_kwargs)
-    with patch.object(etcd.Client, 'read', read):
-        obj.run()
-    with patch.object(etcd.Client, 'read', read):
-        obj.run()
-    with patch.object(Client, "read", read):
-        obj.run()
+
+    intr_obj = IsNodeTendrlManaged()
+    intr_obj.parameters = maps.NamedDict()
+    mock_client.return_value = etcd.Client()
+
+    # no node ids
+    intr_obj.parameters["Node[]"] = []
+    with pytest.raises(AtomExecutionFailedError):
+        intr_obj.run()
+
+    # with one node id
+    intr_obj.parameters["Node[]"] = ["Test_node"]
+    intr_obj.run()
+
+
+@patch.object(etcd_utils, "read")
+def test_os_check(mock_etcd_read):
+    node_id = "Test_node"
     mock_etcd_read.return_value = maps.NamedDict(
         leaves=None,
         value='{"status": "UP",'
@@ -61,10 +53,83 @@ def test_run(mock_etcd_read, mock_read, mock_client):
               '"locked_by": "fd",'
               '"fqdn": "tendrl-node-test",'
               '"leaves: None",'
-              '"last_sync": "date"}')
+              '"last_sync": "date"}'
+    )
+    with pytest.raises(AtomExecutionFailedError):
+        os_check(node_id)
+
     with pytest.raises(AtomExecutionFailedError):
         with patch.object(etcd_utils, "read", read):
-            obj.run()
+            os_check(node_id)
+
+
+@patch.object(etcd_utils, "read")
+def test_cpu_check(mock_etcd_read):
+    node_id = "Test_node"
+    mock_etcd_read.return_value = maps.NamedDict(
+        leaves=None,
+        value='{"status": "UP",'
+              '"pkey": "tendrl-node-test",'
+              '"node_id": "test_node_id",'
+              '"ipv4_addr": "test_ip",'
+              '"tags": "[\\"my_tag\\"]",'
+              '"sync_status": "done",'
+              '"locked_by": "fd",'
+              '"fqdn": "tendrl-node-test",'
+              '"leaves: None",'
+              '"last_sync": "date"}'
+    )
     with pytest.raises(AtomExecutionFailedError):
-        with patch.object(etcd_utils.read, "leaves", None):
-            obj.run()
+        cpu_check(node_id)
+
+    with pytest.raises(AtomExecutionFailedError):
+        with patch.object(etcd_utils, "read", read):
+            cpu_check(node_id)
+
+
+@patch.object(etcd_utils, "read")
+def test_memory_check(mock_etcd_read):
+    node_id = "Test_node"
+    mock_etcd_read.return_value = maps.NamedDict(
+        leaves=None,
+        value='{"status": "UP",'
+              '"pkey": "tendrl-node-test",'
+              '"node_id": "test_node_id",'
+              '"ipv4_addr": "test_ip",'
+              '"tags": "[\\"my_tag\\"]",'
+              '"sync_status": "done",'
+              '"locked_by": "fd",'
+              '"fqdn": "tendrl-node-test",'
+              '"leaves: None",'
+              '"last_sync": "date"}'
+    )
+    with pytest.raises(AtomExecutionFailedError):
+        memory_check(node_id)
+
+    with pytest.raises(AtomExecutionFailedError):
+        with patch.object(etcd_utils, "read", read):
+            memory_check(node_id)
+
+
+@patch.object(etcd_utils, "read")
+def test_network_check(mock_etcd_read):
+    node_id = "Test_node"
+    mock_etcd_read.return_value = maps.NamedDict(
+        leaves=None,
+        value='{"status": "UP",'
+              '"pkey": "tendrl-node-test",'
+              '"node_id": "test_node_id",'
+              '"ipv4_addr": "test_ip",'
+              '"tags": "[\\"my_tag\\"]",'
+              '"sync_status": "done",'
+              '"locked_by": "fd",'
+              '"fqdn": "tendrl-node-test",'
+              '"leaves: None",'
+              '"last_sync": "date"}'
+    )
+    with pytest.raises(AtomExecutionFailedError):
+        network_check(node_id)
+
+    with pytest.raises(AtomExecutionFailedError):
+        with patch.object(etcd_utils, "read", read):
+            network_check(node_id)


### PR DESCRIPTION
I moved the various tests the objects "run" method makes into separate functions for ease of testing - functionality should be identical.

I've included a modified unit test for the changed file in this PR.