### PR TITLE
Set the cluster status as expand_pending if expansion failed

### DIFF
--- a/tendrl/commons/tests/flows/expand_cluster_with_detected_peers/test_ecwdp_init.py
+++ b/tendrl/commons/tests/flows/expand_cluster_with_detected_peers/test_ecwdp_init.py
@@ -127,14 +127,16 @@ def test_expand_cluster_with_detected_peers(patch_etcd_utils_read,
     param['TendrlContext.integration_id'] = "integration_id"
     param['TendrlContext.sds_name'] = "test_sds"
     # Run call that covers through about half of the method
-    expand_cluster_with_detected_peers.run()
+    with pytest.raises(FlowExecutionFailedError):
+        expand_cluster_with_detected_peers.run()
     # Checks for error that is called when EtcdKeyNotFound
     with patch.object(etcd_utils, "read", read):
         with pytest.raises(FlowExecutionFailedError):
             expand_cluster_with_detected_peers.run()
     # Change is managed so that the if statement (Line 85-87) gets covered
     NS.tendrl.objects.ClusterNodeContext = MockCNCManaged
-    expand_cluster_with_detected_peers.run()
+    with pytest.raises(FlowExecutionFailedError):
+        expand_cluster_with_detected_peers.run()
 
 
 @mock.patch('tendrl.commons.event.Event.__init__',


### PR DESCRIPTION
This is required to make sure user should be able to execute
expansion again after cleaning the issues with the underlying
cluster.

tendrl-bug-id: Tendrl/commons#1039
bugzilla: 1596655
Signed-off-by: Shubhendu <shtripat@redhat.com>